### PR TITLE
Details screen design and workflow implemented

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -2,7 +2,7 @@ import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { HomeScreen } from "./Screens/HomeScreen";
-import screens from "./ReproExamples/Issues";
+import { DetailsScreen } from "./Screens/DetailsScreen";
 
 const Stack = createNativeStackNavigator();
 
@@ -11,13 +11,7 @@ const App = () => {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Home" component={HomeScreen} />
-        {screens.map((screen) => (
-          <Stack.Screen
-            name={screen.name}
-            component={screen.component}
-            key={screen.name}
-          />
-        ))}
+        <Stack.Screen name="Details" component={DetailsScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/source/ReproWidget.js
+++ b/source/ReproWidget.js
@@ -29,6 +29,8 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
     }
   };
 
+  const platform = getLabelFromData();
+
   return (
     <TouchableOpacity
       accessibilityRole="button"
@@ -37,9 +39,12 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
         { borderLeftColor: data.state === "closed" ? "#8250DF" : "#1A7F37" },
       ]}
       onPress={() => {
-        navigation.navigate(String(issueNumber), {
+        navigation.navigate("Details", {
           issue: issueNumber,
+          title: data.title,
           url: data.html_url,
+          platform: platform,
+          dateCreated: data.created_at,
         });
       }}
     >
@@ -47,7 +52,7 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
         <Text style={styles.issueHeader}>
           {issueNumber}: {data.title}
         </Text>
-        <Text style={styles.issueBrief}>Platform: {getLabelFromData()}</Text>
+        <Text style={styles.issueBrief}>Platform: {platform}</Text>
       </View>
     </TouchableOpacity>
   );

--- a/source/Screens/DetailsScreen.js
+++ b/source/Screens/DetailsScreen.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient();
+
+export function DetailsScreen({ navigation }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <View style={styles.mainLayout}>
+        <View style={styles.header}></View>
+        <View style={styles.reproExample}></View>
+        <View style={styles.footer}></View>
+      </View>
+    </QueryClientProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  mainLayout: {
+    flex: 1,
+    alignItems: "stretch",
+    justifyContent: "center",
+  },
+  header: {
+    margin: 20,
+  },
+  footer: {
+    margin: 20,
+  },
+  reproExample: {
+    margin: 20,
+  },
+});

--- a/source/Screens/DetailsScreen.js
+++ b/source/Screens/DetailsScreen.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, StyleSheet, Text, Linking } from "react-native";
 import { QueryClient, QueryClientProvider } from "react-query";
+import screens from "../ReproExamples/Issues";
 
 const queryClient = new QueryClient();
 
@@ -18,7 +19,11 @@ export function DetailsScreen({ route }) {
             Created: {new Date(route.params.dateCreated).toDateString()}
           </Text>
         </View>
-        <View style={styles.reproExample}></View>
+        <View style={styles.reproExample}>
+          {screens
+            .find((issue) => issue.name === route.params.issue)
+            .component()}
+        </View>
         <View style={styles.footer}>
           <Text
             style={styles.issueLinkText}

--- a/source/Screens/DetailsScreen.js
+++ b/source/Screens/DetailsScreen.js
@@ -1,16 +1,32 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text, Linking } from "react-native";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 const queryClient = new QueryClient();
 
-export function DetailsScreen({ navigation }) {
+export function DetailsScreen({ route }) {
   return (
     <QueryClientProvider client={queryClient}>
       <View style={styles.mainLayout}>
-        <View style={styles.header}></View>
+        <View style={styles.header}>
+          <Text style={styles.titleText}>{route.params.title}</Text>
+          <Text style={styles.headerText}>Issue: {route.params.issue}</Text>
+          <Text style={styles.headerText}>
+            Platform: {route.params.platform}
+          </Text>
+          <Text style={styles.headerText}>
+            Created: {new Date(route.params.dateCreated).toDateString()}
+          </Text>
+        </View>
         <View style={styles.reproExample}></View>
-        <View style={styles.footer}></View>
+        <View style={styles.footer}>
+          <Text
+            style={styles.issueLinkText}
+            onPress={() => Linking.openURL(route.params.url)}
+          >
+            Go to issue
+          </Text>
+        </View>
       </View>
     </QueryClientProvider>
   );
@@ -19,16 +35,36 @@ export function DetailsScreen({ navigation }) {
 const styles = StyleSheet.create({
   mainLayout: {
     flex: 1,
-    alignItems: "stretch",
-    justifyContent: "center",
   },
   header: {
+    justifyContent: "space-around",
     margin: 20,
+    borderBottomWidth: 1,
+  },
+  headerText: {
+    fontSize: 15,
+    fontWeight: "600",
+    fontFamily: "Roboto",
+    color: "black",
+  },
+  titleText: {
+    fontSize: 18,
+    fontWeight: "800",
+    fontFamily: "Roboto",
+    color: "black",
+    alignSelf: "center",
   },
   footer: {
     margin: 20,
+    alignItems: "center",
+    borderTopWidth: 1,
   },
   reproExample: {
+    height: "60%",
     margin: 20,
+  },
+  issueLinkText: {
+    color: "blue",
+    textDecorationLine: "underline",
   },
 });


### PR DESCRIPTION
This pull request introduces the full workflow and design of the Details screen of an issue.
Once issue is selected and clicked, the Details screen will contain some constant elements (like description, creation date, etc) and footer with a href with the link to the original issue on the Github.

In the middle there'll be the the example implemented separately and assigned to specific issue.

The screen looks like following:
![obraz](https://user-images.githubusercontent.com/70535775/162488790-436b403a-6bd1-4546-be21-c2a6998089ec.png)
