### PR TITLE
Use Animated API to render the animated loading indicator

### DIFF
--- a/ios/rnSliderReproApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/rnSliderReproApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/source/Components/Loading.js
+++ b/source/Components/Loading.js
@@ -1,0 +1,11 @@
+import React from "react";
+import {} from 'react-native';
+
+class Loading extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+}
+
+export default Loading;

--- a/source/Components/Loading.js
+++ b/source/Components/Loading.js
@@ -1,11 +1,91 @@
 import React from "react";
-import {} from 'react-native';
+import { Animated, View, StyleSheet, Text } from 'react-native';
 
 class Loading extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      rotationDegree: new Animated.Value(0)
+    };
   }
 
+  componentDidMount() {
+    Animated.timing(this.state.rotationDegree, {
+      toValue: 360,
+      duration: this.props.duration,
+      useNativeDriver: true
+    }).start();
+  };
+  
+  render() {
+    const rotation = this.state.rotationDegree.interpolate({
+      inputRange: [0, 360],
+      outputRange: ['0deg', '360deg']
+    });
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.reproWidget}>
+          <Animated.View style={[styles.indicator, {
+              transform: [{ rotate: rotation }]
+            }]}
+            useNativeDriver={true}>
+            <View style={[styles.pointer, {
+              transform: [{ rotate: `${this.props.number}deg`}, {translateY: 5}]
+            }]}/>
+          </Animated.View>
+          <Text style={styles.loadingText}>Still loading...</Text>
+        </View>
+      </View>
+    );
+  }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  reproWidget: {
+    flex: 1,
+    flexDirection: "row",
+    margin: 20,
+    borderBottomWidth: 1,
+    borderTopWidth: 1,
+    borderLeftWidth: 10,
+    borderLeftColor: "blue",
+    width: "90%"
+  },
+  indicator: {
+    height: 30,
+    width: 30,
+    margin: 10,
+    borderColor: "gray",
+    borderWidth: 5,
+    borderRadius: 30,
+    alignSelf: "center",
+    justifyContent: "center",
+    alignItems: "center",
+    alignContent: "center"
+  },
+  pointer: {
+    height: 30,
+    width: 1,
+    alignSelf: "center",
+    borderColor: "white",
+    borderWidth: 2
+  },
+  loadingText: {
+    fontSize: 14
+  },
+  issueHeader: {
+    fontWeight: "bold",
+    margin: 5,
+  },
+  issueBrief: {
+    margin: 5,
+  },
+});
 
 export default Loading;

--- a/source/Components/Loading.js
+++ b/source/Components/Loading.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { Animated, View, StyleSheet, Text } from 'react-native';
+import { Animated, View, StyleSheet, Text } from "react-native";
 
 class Loading extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      rotationDegree: new Animated.Value(0)
+      rotationDegree: new Animated.Value(0),
     };
   }
 
@@ -13,26 +13,39 @@ class Loading extends React.Component {
     Animated.timing(this.state.rotationDegree, {
       toValue: 360,
       duration: this.props.duration,
-      useNativeDriver: true
+      useNativeDriver: true,
     }).start();
-  };
-  
+  }
+
   render() {
     const rotation = this.state.rotationDegree.interpolate({
       inputRange: [0, 360],
-      outputRange: ['0deg', '360deg']
+      outputRange: ["0deg", "360deg"],
     });
 
     return (
       <View style={styles.container}>
         <View style={styles.reproWidget}>
-          <Animated.View style={[styles.indicator, {
-              transform: [{ rotate: rotation }]
-            }]}
-            useNativeDriver={true}>
-            <View style={[styles.pointer, {
-              transform: [{ rotate: `${this.props.number}deg`}, {translateY: 5}]
-            }]}/>
+          <Animated.View
+            style={[
+              styles.indicator,
+              {
+                transform: [{ rotate: rotation }],
+              },
+            ]}
+            useNativeDriver={true}
+          >
+            <View
+              style={[
+                styles.pointer,
+                {
+                  transform: [
+                    { rotate: `${this.props.number}deg` },
+                    { translateY: 5 },
+                  ],
+                },
+              ]}
+            />
           </Animated.View>
           <Text style={styles.loadingText}>Still loading...</Text>
         </View>
@@ -45,7 +58,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: "center",
-    justifyContent: "center"
+    justifyContent: "center",
   },
   reproWidget: {
     flex: 1,
@@ -55,7 +68,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderLeftWidth: 10,
     borderLeftColor: "blue",
-    width: "90%"
+    width: "90%",
   },
   indicator: {
     height: 30,
@@ -67,24 +80,17 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     justifyContent: "center",
     alignItems: "center",
-    alignContent: "center"
+    alignContent: "center",
   },
   pointer: {
     height: 30,
     width: 1,
     alignSelf: "center",
     borderColor: "white",
-    borderWidth: 2
+    borderWidth: 2,
   },
   loadingText: {
-    fontSize: 14
-  },
-  issueHeader: {
-    fontWeight: "bold",
-    margin: 5,
-  },
-  issueBrief: {
-    margin: 5,
+    fontSize: 14,
   },
 });
 

--- a/source/ReproWidget.js
+++ b/source/ReproWidget.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { useQuery } from "react-query";
 import Loading from "./Components/Loading";
@@ -9,13 +9,9 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
       `https://api.github.com/repos/callstack/react-native-slider/issues/${issueNumber}`
     ).then((res) => res.json())
   );
-  const [isAnimating, setIsAnimating] = useState(true);
   const loadingAnimationDurationMs = 1000;
 
-  if (isLoading || isAnimating) {
-    setTimeout(() => {
-      setIsAnimating(false);
-    }, loadingAnimationDurationMs);
+  if (isLoading) {
     return (
       <Loading duration={loadingAnimationDurationMs} number={issueNumber} />
     );

--- a/source/ReproWidget.js
+++ b/source/ReproWidget.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { useQuery } from "react-query";
 import Loading from "./Components/Loading";
@@ -9,11 +9,14 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
       `https://api.github.com/repos/callstack/react-native-slider/issues/${issueNumber}`
     ).then((res) => res.json())
   );
+  const [isAnimating, setIsAnimating] = useState(true);
+  const loadingAnimationDurationMs = 1000;
 
-  if (isLoading) {
-    return (
-      <Loading />
-    );
+  if (isLoading || isAnimating) {
+    setTimeout(() => {
+      setIsAnimating(false);
+    }, loadingAnimationDurationMs);
+    return <Loading duration={loadingAnimationDurationMs} number={issueNumber}/>;
   }
 
   const getLabelFromData = () => {
@@ -64,6 +67,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderLeftWidth: 10,
     borderLeftColor: "blue",
+    width: "90%"
   },
   issueHeader: {
     fontWeight: "bold",

--- a/source/ReproWidget.js
+++ b/source/ReproWidget.js
@@ -16,7 +16,9 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
     setTimeout(() => {
       setIsAnimating(false);
     }, loadingAnimationDurationMs);
-    return <Loading duration={loadingAnimationDurationMs} number={issueNumber}/>;
+    return (
+      <Loading duration={loadingAnimationDurationMs} number={issueNumber} />
+    );
   }
 
   const getLabelFromData = () => {
@@ -67,7 +69,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderLeftWidth: 10,
     borderLeftColor: "blue",
-    width: "90%"
+    width: "90%",
   },
   issueHeader: {
     fontWeight: "bold",

--- a/source/ReproWidget.js
+++ b/source/ReproWidget.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { useQuery } from "react-query";
+import Loading from "./Components/Loading";
 
 export const ReproWidget = ({ navigation, issueNumber }) => {
   const { isLoading, data } = useQuery(issueNumber, () =>
@@ -11,9 +12,7 @@ export const ReproWidget = ({ navigation, issueNumber }) => {
 
   if (isLoading) {
     return (
-      <View style={styles.reproWidget}>
-        <Text>Still loading the data...</Text>
-      </View>
+      <Loading />
     );
   }
 

--- a/source/Screens/HomeScreen.js
+++ b/source/Screens/HomeScreen.js
@@ -33,6 +33,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "stretch",
     justifyContent: "center",
+    backgroundColor: "white",
   },
   mainIntroText: {
     margin: 20,


### PR DESCRIPTION
This pull request plays a bit with the [Animated API](https://reactnative.dev/docs/animations#methods).
It makes the loading of the data more fancy by showing "hand made" spinner in the Repro widget.

---

**How does it work?**

Previously the loading was indicated statically by rendering the empty widget with the loading text in it.
This pull request renders the animated spinner in the widget.

NOTE: This pull request significantly increases the waiting time for loading the data - this is only a fake timeout added **only** to make the animation visible. Without this fake timeout the animation would end very quickly, unnoticeably.

The result is presented below:

https://user-images.githubusercontent.com/70535775/171504761-c3b26476-19cb-4e45-9ca6-f698bd6bac7a.mov


---

**Key learnings:**
Playing around with Animated API and Transform API from react native shows that:
* the API is very stable and feels very decent, also easy to use.
* Animations can be very customizable by delaying, ending sooner
* Animations can be launched in parallel or can be easily combined
(this was not done in this PR, though)
* Animations can be way more advanced by combining animated values or using built-in algorithms.
* Animations can be synchronized by launching them in order
* Callback passed to `start` method can be easily used in many scenarios where some state should be updated at the end of an animation.
* Not all components can be used with Animated API.
Currently only: `View`, `Text`, `ScrollView`, `Image` are supported.